### PR TITLE
Debug and tick time

### DIFF
--- a/lua/lagdetect/cl_lagdetect.lua
+++ b/lua/lagdetect/cl_lagdetect.lua
@@ -50,5 +50,11 @@ net.Receive("lagdetect_scale", function()
         lagPanel = vgui.Create("LagDetectPanel")
     end
 
+    if net.ReadBool() then
+        lagPanel:SetLastTick(net.ReadFloat())
+
+        return
+    end
+
     lagPanel:SetScale(net.ReadFloat())
 end)

--- a/lua/lagdetect/cl_lagdetectpanel.lua
+++ b/lua/lagdetect/cl_lagdetectpanel.lua
@@ -75,7 +75,7 @@ function PANEL:PaintLastTick()
 
     local clipping = DisableClipping(true)
     draw.Text({
-        text = "tick: " .. self.LastTick .. " ms",
+        text = "tick: " .. math.Round(self.LastTick, 2) .. " ms",
         pos = { self:GetWide() - 2, self:GetTall() + 2 },
         font = "LagDetectTick",
         xalign = TEXT_ALIGN_RIGHT

--- a/lua/lagdetect/cl_lagdetectpanel.lua
+++ b/lua/lagdetect/cl_lagdetectpanel.lua
@@ -13,11 +13,17 @@ function PANEL:Init()
     self:SetAlpha(0)
     self.Scale = 1
     self.ScaleTween = self.Scale
+
+    self.LastTick = -1
 end
 
 function PANEL:SetScale(scale)
     self.Scale = scale
     self:Reveal(scale <= 0.999)
+end
+
+function PANEL:SetLastTick(lastTick)
+    self.LastTick = lastTick
 end
 
 function PANEL:Reveal(goOut)
@@ -43,6 +49,7 @@ function PANEL:Paint(w, h)
     surface.DrawRect(0, 0, w, h)
 
     self:PaintBar(0, h * 0.75, w, h)
+    self:PaintLastTick()
 end
 
 local blur = Material("pp/blurscreen")
@@ -60,6 +67,19 @@ function PANEL:Blur()
         surface.DrawTexturedRect(-x, -y, ScrW(), ScrH())
     end
 
+    DisableClipping(clipping)
+end
+
+function PANEL:PaintLastTick()
+    if self.LastTick < 0 then return end
+
+    local clipping = DisableClipping(true)
+    draw.Text({
+        text = "tick: " .. self.LastTick .. " ms",
+        pos = { self:GetWide() - 2, self:GetTall() + 2 },
+        font = "LagDetectTick",
+        xalign = TEXT_ALIGN_RIGHT
+    })
     DisableClipping(clipping)
 end
 

--- a/lua/lagdetect/sv_lagdetect.lua
+++ b/lua/lagdetect/sv_lagdetect.lua
@@ -69,9 +69,8 @@ local function ChangeTimeScale(scale, ms, svr)
         if debug_mode:GetBool() then
             local tick = {}
             if ms then
-                tick = { msgcolor, " (last tick: ", ms, " ms)" }
+                tick = { msgcolor, " (last tick: ", ms, " ms) (cooldown: ", Cooldown(level, ms), " s)" }
             end
-            table.Add(tick, { " (cooldown: ", Cooldown(level, ms), " s)" })
 
             Notify(false, msgcolor, "[dbg] maintaining phys_timescale of ", svrc, tostring(scale), unpack(tick))
         end
@@ -82,10 +81,10 @@ local function ChangeTimeScale(scale, ms, svr)
     local tick = {}
     if ms then
         tick = { msgcolor, " (last tick: ", ms, " ms)" }
-    end
 
-    if debug_mode:GetBool() then
-        table.Add(tick, { " (cooldown: ", Cooldown(level, ms), " s)" })
+        if debug_mode:GetBool() then
+            table.Add(tick, { " (cooldown: ", Cooldown(level, ms), " s)" })
+        end
     end
 
     Notify(false, msgcolor, "Setting phys_timescale to ", svrc, tostring(scale), unpack(tick))
@@ -252,7 +251,7 @@ hook.Add("Think", "lagdetector", function()
             timer.Start("cooldown") -- refresh the cooldown
 
             --for displaying the timescale in debug
-            ChangeTimeScale(ts, ms)
+            ChangeTimeScale(ts, t)
         end
 
         return

--- a/lua/lagdetect/sv_lagdetect.lua
+++ b/lua/lagdetect/sv_lagdetect.lua
@@ -23,6 +23,7 @@ cvars.AddChangeCallback("phys_timescale", function(_, oldScale, scale)
     if math.abs(oldScale - scale) <= 0.0001 then return end
 
     net.Start("lagdetect_scale")
+        net.WriteBool(false)
         net.WriteFloat(scale)
     net.Broadcast()
 end)
@@ -44,8 +45,8 @@ local function Notify(broadcastType, ...)
     if broadcastType == false then return end
 
     net.Start("lagdetect_notify")
-    net.WriteTable(textTable, true)
-    net.WriteBool(notify)
+        net.WriteTable(textTable, true)
+        net.WriteBool(notify)
 
     if broadcastType == true then
         local tbl = {}
@@ -60,6 +61,13 @@ end
 
 local function ChangeTimeScale(scale, ms, svr)
     local svrc = HSVToColor(-svrcolor + (svr or 0) * svrcolor, 0.8, 1)
+
+    if ms then
+        net.Start("lagdetect_scale")
+            net.WriteBool(true)
+            net.WriteFloat(ms)
+        net.Broadcast()
+    end
 
     if math.abs(cv:GetFloat() - scale) <= 0.001 then
         if scale == 1 then

--- a/lua/lagdetect/sv_lagdetect.lua
+++ b/lua/lagdetect/sv_lagdetect.lua
@@ -64,6 +64,8 @@ local function ChangeTimeScale(scale, ms, svr)
     if math.abs(cv:GetFloat() - scale) <= 0.001 then
         if scale == 1 then
             Notify(false, msgcolor, "phys_timescale returned to ", svrc, 1)
+
+            return
         end
 
         if debug_mode:GetBool() then


### PR DESCRIPTION
- Changed `lagdetect_debug` to `lagdetect_debug_dump`
- `lagdetect_debug` is now a convar that enables the formerly-removed info/notifications
- Timescale notification has tick time included
- Timescale ui has tick time included